### PR TITLE
Fix misspelled words

### DIFF
--- a/web/assets/js/actions.ts
+++ b/web/assets/js/actions.ts
@@ -1,22 +1,22 @@
-import {saveToLocalStorage} from './utils/localstorage';
+import { saveToLocalStorage } from './utils/localstorage';
 import {
-    defaultFaucetTokenKey,
-    defaultMnemonicKey,
-    drawRequestTimer,
-    Game,
-    type GameoverType,
-    type GameSettings,
-    GameState,
-    GameTime,
-    Player,
-    Promotion
+  defaultFaucetTokenKey,
+  defaultMnemonicKey,
+  drawRequestTimer,
+  Game,
+  type GameoverType,
+  type GameSettings,
+  GameState,
+  GameTime,
+  Player,
+  Promotion
 } from './types/types';
-import {defaultTxFee, GnoWallet, GnoWSProvider} from '@gnolang/gno-js-client';
-import {BroadcastTxCommitResult, TransactionEndpoint} from '@gnolang/tm2-js-client';
-import {generateMnemonic} from './utils/crypto.ts';
+import { defaultTxFee, GnoWallet, GnoWSProvider } from '@gnolang/gno-js-client';
+import { BroadcastTxCommitResult, TransactionEndpoint } from '@gnolang/tm2-js-client';
+import { generateMnemonic } from './utils/crypto.ts';
 import Long from 'long';
 import Config from './config.ts';
-import {constructFaucetError} from './utils/errors.ts';
+import { constructFaucetError } from './utils/errors.ts';
 
 // ENV values //
 const wsURL: string = Config.GNO_WS_URL;
@@ -39,7 +39,7 @@ class Actions {
   private faucetToken: string | null = null;
   private isInTheLobby = false;
 
-  private constructor() {}
+  private constructor() { }
 
   /**
    * Fetches the Actions instance. If no instance is
@@ -181,7 +181,7 @@ class Actions {
 
       const fetchInterval = setInterval(async () => {
         try {
-          if (!this.isInTheLobby) reject('Leaved the lobby');
+          if (!this.isInTheLobby) reject('Left the lobby');
 
           // Check if the game is ready
           const lobbyResponse: BroadcastTxCommitResult =

--- a/web/assets/js/components/gameoptions.ts
+++ b/web/assets/js/components/gameoptions.ts
@@ -288,7 +288,7 @@ const Gameoptions = class extends Component {
             this.lookingForRival = false;
             this.call(
               'appear',
-              ['Leaved game lobby, try again.', 'warning'],
+              ['Left game lobby, try again.', 'warning'],
               'toast'
             );
             return;


### PR DESCRIPTION
This PR replaces **Leaved** with **Left** (+ apparently adds some whitespaces as well but these are unintentional/unimportant).

---

Upon clicking "Play Now" and entering a game's waiting pool, if you leave this screen and navigate to a different page (ie, /About), then the user will eventually (after a few seconds) be presented with a popup.

> Leaved game lobby, try again.

<img width="1049" alt="Screenshot 2023-09-21 at 2 00 18 PM" src="https://github.com/gnolang/gnochess/assets/17755587/4a99dc8f-4757-47c6-bf7e-6c3bec007e5a">