### PR TITLE
feat(faucet): bind tokens to address

### DIFF
--- a/faucet/.gitignore
+++ b/faucet/.gitignore
@@ -10,3 +10,6 @@
 
 # Build Leftovers
 build/*
+
+# storage directory
+data

--- a/web/assets/js/components/gameoptions.ts
+++ b/web/assets/js/components/gameoptions.ts
@@ -362,7 +362,7 @@ const Gameoptions = class extends Component {
         isTokenError = true;
         this.DOM.el.querySelector('#id-gameoptions-token').value = '';
         this.DOM.ctrl1.innerHTML = 'Connection';
-        this.call('appear', ['Invalid token', 'error'], 'toast');
+        this.call('appear', [e, 'error'], 'toast');
       }
     }
     this.disabled = false;

--- a/web/assets/js/types/errors.ts
+++ b/web/assets/js/types/errors.ts
@@ -16,8 +16,15 @@ class InvalidTokenError extends FaucetError {
   }
 }
 
+class TokenAlreadyBoundError extends FaucetError {
+  constructor() {
+    super('Faucet token already bound to an other address');
+  }
+}
+
 export {
   FaucetError,
   UserFundedError,
-  InvalidTokenError
+  InvalidTokenError,
+  TokenAlreadyBoundError
 };

--- a/web/assets/js/utils/errors.ts
+++ b/web/assets/js/utils/errors.ts
@@ -1,6 +1,7 @@
 import {
   FaucetError,
   InvalidTokenError,
+  TokenAlreadyBoundError,
   UserFundedError
 } from '../types/errors.ts';
 
@@ -10,6 +11,8 @@ export const constructFaucetError = (message: string): FaucetError => {
       return new UserFundedError();
     case 'Invalid faucet token':
       return new InvalidTokenError();
+		case 'Faucet token already bound to an other address':
+      return new TokenAlreadyBoundError();
     default:
       return new FaucetError(message);
   }


### PR DESCRIPTION
Closes #61

Returns an error if a token is already bound to an address. Works only in memory, bound tokens are reset on restart.

This is the dumbest possible change to avoid new bugs since there's no tests.