### PR TITLE
fix: Query returns do not need base64-decoding

### DIFF
--- a/web/assets/js/actions.ts
+++ b/web/assets/js/actions.ts
@@ -279,7 +279,7 @@ class Actions {
     )) as string;
 
     // Parse the response
-    return JSON.parse(decodeRealmResponse(gameResponse));
+    return JSON.parse(cleanUpRealmReturn(gameResponse));
   }
 
   /**
@@ -408,7 +408,7 @@ class Actions {
             )) as string;
 
           // Parse the response
-          const game: Game = JSON.parse(decodeRealmResponse(getGameResponse));
+          const game: Game = JSON.parse(cleanUpRealmReturn(getGameResponse));
 
           if (game.state === GameState.DRAWN_INSUFFICIENT) {
             // Clear the fetch interval
@@ -533,7 +533,7 @@ class Actions {
       )) as string;
 
     // Parse the response
-    return JSON.parse(decodeRealmResponse(leaderboardResponse));
+    return JSON.parse(cleanUpRealmReturn(leaderboardResponse));
   }
 
   /**
@@ -547,7 +547,7 @@ class Actions {
     )) as string;
 
     // Parse the response
-    return JSON.parse(decodeRealmResponse(playerResponse));
+    return JSON.parse(cleanUpRealmReturn(playerResponse));
   }
 
   /**


### PR DESCRIPTION
As per my slack comments, return values for queries (i.e. called using `evaluateExpression()`) are not base64-encoded and only need to be passed through `cleanUpRealmResponse()` which extracts `<JsonString>` from the `("<JsonString>" string)` realm response.

Tx result data ( obtained using `callMethod()` )are the same but base64-encoded and need to be passed through `decodeRealmResponse()`