### PR TITLE
chore: setup simpleanalytics

### DIFF
--- a/signup/index.html
+++ b/signup/index.html
@@ -9,5 +9,8 @@
   <body>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
+    <!-- 100% privacy-first analytics -->
+    <script async defer src="https://scripts.simpleanalyticscdn.com/latest.js"></script>
+    <noscript><img src="https://queue.simpleanalyticscdn.com/noscript.gif" alt="" referrerpolicy="no-referrer-when-downgrade" /></noscript>
   </body>
 </html>

--- a/web/layouts/_default/baseof.html
+++ b/web/layouts/_default/baseof.html
@@ -20,5 +20,8 @@
       integrity="sha384-8Vi8VHwn3vjQ9eUHUxex3JSN/NFqUg3QbPyX8kWyb93+8AC/pPWTzj+nHtbC5bxD"
       crossorigin="anonymous"
     ></script>
+    <!-- 100% privacy-first analytics -->
+    <script async defer src="https://scripts.simpleanalyticscdn.com/latest.js"></script>
+    <noscript><img src="https://queue.simpleanalyticscdn.com/noscript.gif" alt="" referrerpolicy="no-referrer-when-downgrade" /></noscript>
   </body>
 </html>

--- a/web/layouts/_default/baseof.html
+++ b/web/layouts/_default/baseof.html
@@ -20,8 +20,10 @@
       integrity="sha384-8Vi8VHwn3vjQ9eUHUxex3JSN/NFqUg3QbPyX8kWyb93+8AC/pPWTzj+nHtbC5bxD"
       crossorigin="anonymous"
     ></script>
+    {{ if hugo.IsProduction }}
     <!-- 100% privacy-first analytics -->
     <script async defer src="https://scripts.simpleanalyticscdn.com/latest.js"></script>
     <noscript><img src="https://queue.simpleanalyticscdn.com/noscript.gif" alt="" referrerpolicy="no-referrer-when-downgrade" /></noscript>
+    {{ end }}
   </body>
 </html>


### PR DESCRIPTION
I've invited some people to the simpleanalytics.com organization.

It's a great analytics service that respects privacy, and the setup is straightforward. No custom GA-XXX code; the hostname manages everything.

An improvement could be to find the Hugo way to disable it when developing locally to avoid a useless network call.

Signed-off-by: moul <94029+moul@users.noreply.github.com>
