### PR TITLE
wrap the front-end move in a try

### DIFF
--- a/web/assets/js/components/gameboard.ts
+++ b/web/assets/js/components/gameboard.ts
@@ -340,14 +340,18 @@ const Gameboard = class extends Component {
           move.color === this.color ? 'me' : 'rival'
         );
       }
-
       // ------ Action - emmit my move ------
-      await actions.makeMove(this.gameID, move.from, move.to, promotion);
-      this.engine(); // TODO @Alexis missing await?
+      try {
+        await actions.makeMove(this.gameID, move.from, move.to, promotion);
+        this.engine(); // TODO @Alexis missing await?
 
-      //reset allowed positions
-      gsap.to('.chess-board [data-square]', { '--disp-opacity': 0 });
-      this.DOM.moves = [];
+        //reset allowed positions
+        gsap.to('.chess-board [data-square]', { '--disp-opacity': 0 });
+        this.DOM.moves = [];
+      } catch (e) {
+        this.chess.undo(); //undo move in the headless Chess
+        this.call('appear', [e + ' - try your move again.', 'error'], 'toast');
+      }
     } else {
       // if click on disallow cell (new select)
       if (this.DOM.moves.length > 0) {

--- a/web/assets/js/components/gameboard.ts
+++ b/web/assets/js/components/gameboard.ts
@@ -342,7 +342,7 @@ const Gameboard = class extends Component {
       }
       // ------ Action - emmit my move ------
       try {
-        await actions.makeMove(this.gameID, move.from, move.to, promotion);
+        await actions.makeMove(this.gameId, move.from, move.to, promotion);
         this.engine(); // TODO @Alexis missing await?
 
         //reset allowed positions

--- a/web/assets/js/components/gameboard.ts
+++ b/web/assets/js/components/gameboard.ts
@@ -350,7 +350,9 @@ const Gameboard = class extends Component {
         this.DOM.moves = [];
       } catch (e) {
         this.chess.undo(); //undo move in the headless Chess
-        this.call('appear', [e + ' - try your move again.', 'error'], 'toast');
+        this.board.position(this.chess.fen(), false); //undo move on the board
+
+        this.call('appear', [e + ' - try your move again.', 'error'], 'toast'); //display error
       }
     } else {
       // if click on disallow cell (new select)


### PR DESCRIPTION
We currently move the piece immediately on the UI board for UX reasons, then the function waits the TX to be finished to balance the players by calling engine().  We should wrap the promise un a try and call this future undo() if an error occurs.