### PR TITLE
fix: promotion of pieces

### DIFF
--- a/web/assets/js/actions.ts
+++ b/web/assets/js/actions.ts
@@ -18,6 +18,7 @@ import Long from 'long';
 import Config from './config.ts';
 import {constructFaucetError} from './utils/errors.ts';
 import {AlreadyInLobbyError, ErrorTransform} from './errors.ts';
+import {preparePromotion} from './utils/moves.ts';
 
 // ENV values //
 const wsURL: string = Config.GNO_WS_URL;
@@ -309,7 +310,7 @@ class Actions {
       gameID,
       from,
       to,
-      promotion.toString()
+      preparePromotion(promotion)
     ]);
 
     // Parse the response from the node

--- a/web/assets/js/types/types.ts
+++ b/web/assets/js/types/types.ts
@@ -42,10 +42,10 @@ export enum GameType {
 
 export enum Promotion {
   NO_PROMOTION = 0,
-  QUEEN = 'Q',
-  BISHOP = 'B',
-  KNIGHT = 'N',
-  ROOK = 'R'
+  QUEEN = 'q',
+  BISHOP = 'b',
+  KNIGHT = 'n',
+  ROOK = 'r'
 }
 
 export enum Winner {

--- a/web/assets/js/utils/moves.ts
+++ b/web/assets/js/utils/moves.ts
@@ -1,0 +1,20 @@
+import {Promotion} from '../types/types.ts';
+
+/**
+ * Prepares the promotion parameter
+ * @param {Promotion} promotion the requested promotion
+ */
+export const preparePromotion = (promotion: Promotion): string => {
+  switch (promotion) {
+    case Promotion.ROOK:
+      return '2';
+    case Promotion.KNIGHT:
+      return '3';
+    case Promotion.BISHOP:
+      return '4';
+    case Promotion.QUEEN:
+      return '5';
+    default:
+      return '0';
+  }
+};


### PR DESCRIPTION
## Description

This PR fixes pawn promotion on the frontend. The issue was that the realm was expecting a number value, instead of a string.

Closes #102 