### PR TITLE
Fix: avoid error user is already in the lobby.

### DIFF
--- a/realm/chess.gno
+++ b/realm/chess.gno
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"gno.land/p/demo/avl"
-	"gno.land/p/demo/ufmt"
 )
 
 // realm state
@@ -221,7 +220,10 @@ func xNewGame(opponentRaw string, seconds, increment int) string {
 
 	opponent := parsePlayer(opponentRaw)
 	caller := std.GetOrigCaller()
-	assertUserNotInLobby(caller)
+
+	if isUserInLobby(caller) {
+		panic("you are already in the lobby")
+	}
 
 	return newGame(caller, opponent, seconds, increment).json()
 }

--- a/realm/lobby.gno
+++ b/realm/lobby.gno
@@ -237,6 +237,4 @@ func LobbyQuit() {
 		}
 	}
 	lobbyPlayer2Game.Remove(caller.String())
-
-	panic("you are not in the lobby")
 }

--- a/realm/lobby.gno
+++ b/realm/lobby.gno
@@ -1,7 +1,6 @@
 package chess
 
 import (
-	"math"
 	"std"
 	"time"
 
@@ -84,7 +83,9 @@ func LobbyJoin(seconds, increment int) {
 	caller := std.GetOrigCaller()
 
 	assertGamesFinished(getUserGames(caller))
-	assertUserNotInLobby(caller)
+	if isUserInLobby(caller) {
+		return
+	}
 
 	// remove caller from lobbyPlayer2Game, so LobbyGameFound
 	// returns the right value.
@@ -95,14 +96,16 @@ func LobbyJoin(seconds, increment int) {
 	refreshLobby(tc)
 }
 
-func assertUserNotInLobby(caller std.Address) {
+func isUserInLobby(caller std.Address) bool {
 	for _, sublob := range lobby {
 		for _, pl := range sublob {
 			if pl.player.Address == caller {
-				panic("you are already in the lobby")
+				return true
 			}
 		}
 	}
+
+	return false
 }
 
 // refreshLobby serves to run through the lobby, kick timed out users, and see if any users


### PR DESCRIPTION
If the user refreshes the page and it is already in the lobby, instead of panicking we return. That avoids a frontend error and the flow will remain the same.

Fixes #117