### PR TITLE
fix: the dashboard blitz object initialized from blitz, not rapid

### DIFF
--- a/web/assets/js/components/dashboard.ts
+++ b/web/assets/js/components/dashboard.ts
@@ -82,7 +82,7 @@ const Dashboard = class extends Component {
 
   private _feedUserRating(player: Player) {
     const playerRapidRating: PlayerRating = player.rapid;
-    const playerBlitzRating: PlayerRating = player.rapid;
+    const playerBlitzRating: PlayerRating = player.blitz;
 
     const rapidRating = {
       wins: playerRapidRating.wins,


### PR DESCRIPTION
This should fix #130, although I could not test because the draw button is now disabled. Anyway simple and logic enough.