### PR TITLE
feat(faucet): gno address and email/token mapping

### DIFF
--- a/web/assets/js/components/gameoptions.ts
+++ b/web/assets/js/components/gameoptions.ts
@@ -358,7 +358,7 @@ const Gameoptions = class extends Component {
         isTokenError = true;
         this.DOM.el.querySelector('#id-gameoptions-token').value = '';
         this.DOM.ctrl1.innerHTML = 'Connection';
-        this.call('appear', ['Invalid token', 'error'], 'toast');
+        this.call('appear', [e, 'error'], 'toast');
       }
     }
     this.disabled = false;


### PR DESCRIPTION
Closes #148

- Register in redis the gno address as key and email/token as values
- Add a pseudo endpoint to retrieve email and token from gno adresses

## How to test

You need a redis running : 
```
docker run -d --name redis-stack -p 6379:6379 -p 8001:8001 redis/redis-stack:latest
```
and a redis-cli
```
docker exec -it redis-stack redis-cli
```

Prepare a claimable token (this is what the signup page is doing on submit), using redis-cli : 
```
HSET TOKEN:mytoken email toto@gmail.com
HSET TOKEN:mytoken used false
```

Run the faucet using this command (the default value of `--redis-url` will match the address of the running docker container, so we don't need to provide it) :
```
go run main.go -fund-limit 250000000ugnot -send-amount 1000000000ugnot -mnemonic "piano aim fashion palace key scrap write garage avocado royal lounge lumber remove frozen sketch maze tree model half team cook burden pattern choice" -num-accounts 10
```

Run the node and the gnochess web as usual.

Connect to your gnochess instance with your browser, remove any previous local storage and submit your token:

![image](https://github.com/gnolang/gnochess/assets/92280/926526f3-9b62-4a89-8b25-de86cc042bdb)

You should have no error.

In redis-cli, ensure that the gno address has been stored : 
```
KEYS GNO:*
1) "GNO:g10trepc80pt9h4ed4tqwm8rgqk4g8rjaer4cqgv"

HGETALL GNO:g10trepc80pt9h4ed4tqwm8rgqk4g8rjaer4cqgv
1) "email"
2) "toto@gmail.com"
3) "token"
4) "nytoken"
```

Finally take that address (in normal condition, this address should come from the leaderboard) and go to your faucet URL, append the `?addr=g10trepc80pt9h4ed4tqwm8rgqk4g8rjaer4cqgv` query string :
```
$ curl http://localhost:8545/?addr=g10trepc80pt9h4ed4tqwm8rgqk4g8rjaer4cqgv
{"email":"toto@gmail.com","token":"cah3Shohye"}
```

Please do that testing to ensure that works properly, it's late and I may have made mistakes! thanks in advance :pray: 
