### PR TITLE
fix(web): enforce sequential transactions

### DIFF
--- a/web/assets/js/actions.ts
+++ b/web/assets/js/actions.ts
@@ -1,24 +1,36 @@
-import {saveToLocalStorage} from './utils/localstorage';
+import { saveToLocalStorage } from './utils/localstorage';
 import {
-    Category,
-    defaultFaucetTokenKey,
-    defaultMnemonicKey,
-    drawRequestTimer,
-    Game,
-    type GameSettings,
-    GameState,
-    GameTime,
-    Player,
-    Promotion
+  Category,
+  defaultFaucetTokenKey,
+  defaultMnemonicKey,
+  drawRequestTimer,
+  Game,
+  type GameSettings,
+  GameState,
+  GameTime,
+  Player,
+  Promotion
 } from './types/types';
-import {defaultTxFee, GnoJSONRPCProvider, GnoWallet} from '@gnolang/gno-js-client';
-import {BroadcastTxCommitResult, TM2Error, TransactionEndpoint} from '@gnolang/tm2-js-client';
-import {generateMnemonic} from './utils/crypto.ts';
+import {
+  defaultTxFee,
+  GnoJSONRPCProvider,
+  GnoWallet
+} from '@gnolang/gno-js-client';
+import {
+  BroadcastTxCommitResult,
+  TM2Error,
+  TransactionEndpoint
+} from '@gnolang/tm2-js-client';
+import { generateMnemonic } from './utils/crypto.ts';
 import Long from 'long';
 import Config from './config.ts';
-import {constructFaucetError} from './utils/errors.ts';
-import {AlreadyInLobbyError, ErrorTransform, NotInLobbyError} from './errors.ts';
-import {prepareCategory, preparePromotion} from './utils/moves.ts';
+import { constructFaucetError } from './utils/errors.ts';
+import {
+  AlreadyInLobbyError,
+  ErrorTransform,
+  NotInLobbyError
+} from './errors.ts';
+import { prepareCategory, preparePromotion } from './utils/moves.ts';
 
 // ENV values //
 // const wsURL: string = Config.GNO_WS_URL; TODO temporarily disabled
@@ -143,14 +155,34 @@ class Actions {
     return this.wallet?.getAddress();
   }
 
+  private pending: Promise<BroadcastTxCommitResult> = new Promise(
+    (resolve, _) => {
+      resolve({} as BroadcastTxCommitResult);
+    }
+  );
+
   /**
    * Performs a transaction, handling common error cases and transforming them
    * into known error types.
    */
-  public async callMethod(
+  public callMethod(
     method: string,
     args: string[] | null,
     gasWanted: Long = defaultGasWanted
+  ): Promise<BroadcastTxCommitResult> {
+    // https://is.gd/0GRcsX (sorry for the shortener, link is to TS playground!)
+    console.log('received the call');
+    this.pending = this.pending.finally(async () => {
+      console.log('doing the call');
+      return await this.doCallMethod(method, args, gasWanted);
+    });
+    return this.pending;
+  }
+
+  private async doCallMethod(
+    method: string,
+    args: string[] | null,
+    gasWanted: Long
   ): Promise<BroadcastTxCommitResult> {
     const gkLog = this.gkLog();
     try {

--- a/web/assets/js/actions.ts
+++ b/web/assets/js/actions.ts
@@ -171,9 +171,7 @@ class Actions {
     gasWanted: Long = defaultGasWanted
   ): Promise<BroadcastTxCommitResult> {
     // https://is.gd/0GRcsX (sorry for the shortener, link is to TS playground!)
-    console.log('received the call');
     this.pending = this.pending.finally(async () => {
-      console.log('doing the call');
       return await this.doCallMethod(method, args, gasWanted);
     });
     return this.pending;


### PR DESCRIPTION
Should avoid once and for all "not initialized" issues and "invalid signature" issues.