### PR TITLE
chore: set vscode extension version to v0.0.11

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -75,4 +75,4 @@ github:
 
 vscode:
   extensions:
-    - harry-hov.gno
+    - harry-hov.gno@0.0.11


### PR DESCRIPTION
Latest version of vscode-gno extension utilizes language server to provide some feature.

I opened a PR #122, which configures gitpod to be able to use latest version of vscode-code.

Seems like @thehowl encountered some bugs while testing [vscode-gno + gnopls] 
(See: https://github.com/gnolang/gnochess/pull/122#issuecomment-1735161755)

We have options now: 
- Option1: Stick to old version (this is what this PR does)
- Option2: Merge PR #122 and disable language server if you encounter bugs, than the extension will work like old version
    <img width="740" alt="Screenshot 2023-09-26 at 11 10 57 PM" src="https://github.com/gnolang/gnochess/assets/37576387/f8d6025c-bf81-4aa8-89e6-143ddeec0d72">

   