### PR TITLE
fix: README.md gno help flag

### DIFF
--- a/tutorial/01_getting_started/README.md
+++ b/tutorial/01_getting_started/README.md
@@ -18,7 +18,7 @@ We'll be using two commands in this tutorial, `gno` and `gnokey`.
 Try the next few commands out!
 
 ```console
-$ gno --help
+$ gno help # or just `gno`
 USAGE
   <subcommand> [flags] [<arg>...]
 


### PR DESCRIPTION
Help message is not at `--help` it's now at `gno help` or just `gno` at the current version specified in the gitpod env.


```
gitpod /workspace/gnochess/tutorial/01_getting_started (main) $ gno --help

...

error parsing commandline arguments: flag: help requested
```

Fix:

```
gitpod /workspace/gnochess/tutorial/01_getting_started (main) $ gno help # and `gno`

...

flag: help requested
```