### PR TITLE
fix: specify hugo config file to prevent error

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -3,8 +3,8 @@
   "private": true,
   "version": "0.0.1",
   "scripts": {
-    "dev": "concurrently \"hugo server -D --bind='0.0.0.0' \" \"tsc && vite build --config ./vite.config.server.js \"",
-    "build": "tsc && vite build && hugo --gc",
+    "dev": "concurrently \"hugo --config hugo.toml server -D --bind='0.0.0.0' \" \"tsc && vite build --config ./vite.config.server.js \"",
+    "build": "tsc && vite build && hugo --gc --config hugo.toml ",
     "preview": "vite preview"
   },
   "devDependencies": {


### PR DESCRIPTION
I am using the Makefile to setup the dev environment and hit a bug where `hugo` couldn't find the config file. I am on `v0.108.0` of hugo, I'm not sure if its a version difference, but just added in the explicit config file fixed the issue.