### PR TITLE
fix: Realm timeout calculation

### DIFF
--- a/realm/time.gno
+++ b/realm/time.gno
@@ -95,7 +95,7 @@ func (tc *TimeControl) timedOut() (time.Duration, bool) {
 
 	// Determine color. Determine time since last move. Try subtracting from
 	// color's time. If >= 0, good. If < 0, timeout.
-	delta := time.Since(mts[len(mts)-2])
+	delta := time.Since(mts[len(mts)-1])
 
 	if len(mts)&1 == 0 { // white
 		nt := tc.WhiteTime - delta


### PR DESCRIPTION
The time that should be taken off a player's clock (delta) is the time he spent considering his move (i.e. the time since the rival's last move)

Since MoveTimestamps does not contain the move being examined yet, the  rival's move is the LAST element of the slice...not the one before the last