### PR TITLE
increase max wait time

### DIFF
--- a/web/assets/js/actions.ts
+++ b/web/assets/js/actions.ts
@@ -317,7 +317,7 @@ class Actions {
   private async waitForGame(timeout?: number): Promise<GameSettings> {
     this.isInTheLobby = true;
     let retryTimeout: NodeJS.Timeout;
-    const exitTimeout = timeout ? timeout : drawRequestTimer * 1000; // wait time is max 15s
+    const exitTimeout = timeout ? timeout : drawRequestTimer * 100000; // wait time is max 15s
     return new Promise((resolve, reject) => {
       let exit = setTimeout(() => {
         clearTimeout(retryTimeout);


### PR DESCRIPTION
I've been logging into the chess game this morning and getting bounced off because it is not finding clients. After it can't find someone, I have to press play again, and repeat often. Would it be okay to increase the wait time to allow the computer to sit and wait longer before having to press into it again?