### PR TITLE
chore: In the 01_getting_started tutorial, clarify how to use gnokey add

### DIFF
--- a/tutorial/01_getting_started/README.md
+++ b/tutorial/01_getting_started/README.md
@@ -189,10 +189,13 @@ block" to contain 10^13 ugnot.
 > _ugnot_ is to $GNOT what [satoshi](https://www.investopedia.com/terms/s/satoshi.asp)
 > is to bitcoin; the smallest, indivisible denomination of the token.
 
-Execute the following command, and input the mnemonic below:
+Execute the following command, a passphrase to use the key, the passphrase repeated, and input the mnemonic below:
 
 ```console
 gnokey add test1 --recover
+# Enter a passphrase to encrypt your key to disk:
+# Repeat the passphrase:
+# Enter your bip39 mnemonic
 ```
 
 ```


### PR DESCRIPTION
This is a small clarification in the 01_getting_started tutorial . The instructions say to execute the `gnokey add` command and enter the mnemonic. But the first prompt is "Enter a passphrase to encrypt your key to disk". For my first try (and other people that I've seen), they try to paste the mnemonic here which doesn't work.

This PR updates to make it more clear, similar to the other example for `gnokey add` at the [bottom of the same tutorial](https://github.com/gnolang/gnochess/blob/2ced84db9b3604b228a2036c76edc60297a2f604/tutorial/01_getting_started/README.md?plain=1#L359-L362).